### PR TITLE
Improve Turbo mode performance

### DIFF
--- a/CLIP-Finder2/ContentView.swift
+++ b/CLIP-Finder2/ContentView.swift
@@ -68,7 +68,7 @@ struct ContentView: View {
                                         .foregroundColor(.secondary)
                                         .frame(maxWidth: .infinity, maxHeight: .infinity)
                                 } else {
-                                    PhotoGalleryView(assets: photoGalleryViewModel.assets, topPhotoIDs: photoGalleryViewModel.topPhotoIDs, columns: isPreviewActive ? 4 : 7)
+                                    PhotoGalleryView(assetsByID: photoGalleryViewModel.assetsByID, topPhotoIDs: photoGalleryViewModel.topPhotoIDs, columns: isPreviewActive ? 4 : 7)
                                 }
                             }
                         } else {
@@ -82,7 +82,7 @@ struct ContentView: View {
                                     .foregroundColor(.secondary)
                                     .frame(maxWidth: .infinity, maxHeight: .infinity)
                             } else {
-                                PhotoGalleryView(assets: photoGalleryViewModel.assets, topPhotoIDs: photoGalleryViewModel.topPhotoIDs, columns: 4)
+                                PhotoGalleryView(assetsByID: photoGalleryViewModel.assetsByID, topPhotoIDs: photoGalleryViewModel.topPhotoIDs, columns: 4)
                             }
                         }
                         
@@ -184,7 +184,7 @@ struct SearchBar: View {
 }
 
 struct PhotoGalleryView: View {
-    let assets: [PHAsset]
+    let assetsByID: [String: PHAsset]
     let topPhotoIDs: [String]
     let columns: Int
 
@@ -192,7 +192,7 @@ struct PhotoGalleryView: View {
         ScrollView {
             LazyVGrid(columns: Array(repeating: .init(.flexible()), count: columns), spacing: 0.1) {
                 ForEach(topPhotoIDs, id: \.self) { photoID in
-                    if let asset = assets.first(where: { $0.localIdentifier == photoID }) {
+                    if let asset = assetsByID[photoID] {
                         PhotoGridItemView(asset: asset)
                     }
                 }


### PR DESCRIPTION
This improves the performance of Turbo mode on phones with thousands photos: no freezing, <100% CPU, ~200MB RAM.

Two main fixes:
- `assets.first(where: { $0.localIdentifier == photoID })` was getting called for each top photo each time the top photos changed. I think this was causing SwiftUI to lock up. Switching to a dictionary for O(1) lookups.
- `CoreDataManager.shared.fetchAllPhotoVectors()` is slow when it has to deserialize a lot of MLMultiArray vectors. The vectors are small, so changed to keep them in memory. This speeds up turbo mode for a small amount of RAM. (512 dimension * 16 bit * # of photos is only ~10MB for 10,000 photos)

One nice-to-have fix:
- Added `isSearchingAsync` so that only 1 async request is active at a time. This reduces the CPU usage and energy impact. Turbo mode is still incredibly fast with this.